### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,23 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
+      - run:
+          name: Populate Go Mod Cache
+          command: |
+            if [ ! -d /go/pkg/mod ]; then
+              go mod download
+            fi
+      - save_cache:
+          key: go-mod-{{ checksum "go.sum" }}
+          paths:
+            - '/go/pkg/mod'
       - persist_to_workspace:
           root: /
           paths:
+            - go/pkg/mod/*
             - src/*
 
   build_source:


### PR DESCRIPTION
Pin base CI container to `golang:1.12`. Cache go modules in `get_source` job and pass to following jobs via `persist_to_workspace`. Move working directory outside `GOPATH` to remove need for `GO111MODULE` environment variable.

Based on some recommendations from [this CircleCI blog post](https://circleci.com/blog/go-v1.11-modules-and-circleci/).