### PR TITLE
Remove ZenHub Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # SCS Key Client
 
 <a href="https://circleci.com/gh/sylabs/workflows/scs-key-client"><img src="https://circleci.com/gh/sylabs/scs-key-client.svg?style=shield&circle-token=f2b6e1b11393ccadf9ec8712d76da4a48dc8630d"></a>
-<a href="https://app.zenhub.com/workspace/o/sylabs/scs-key-client/boards"><img src="https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png"></a>
 
 This project provides a Go client for the Singularity Container Services (SCS) Key Service.
 


### PR DESCRIPTION
Remove ZenHub badge, since the project it was hosted under (https://github.com/ZenHubIO/support) seems to have disappeared.