### PR TITLE
Badges and Markdown Lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,9 +111,6 @@ jobs:
       - run:
           name: Run Tests
           command: go test -cover -race -timeout 60s ./...
-      - store_artifacts:
-          path: cover.out
-          destination: cover.out
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,10 +84,11 @@ jobs:
       - attach_workspace:
           at: /
       - run:
+          name: Install golangci-lint
+          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+      - run:
           name: Check for Lint
-          command: |
-            curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
-            golangci-lint run ./...
+          command: golangci-lint run ./...
 
   lint_markdown:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,19 @@ jobs:
             curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
             golangci-lint run ./...
 
+  lint_markdown:
+    docker:
+      - image: circleci/ruby:2.4.1-node
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Install markdownlint
+          command: sudo npm install -g markdownlint-cli
+      - run:
+          name: Check for Lint
+          command: markdownlint --config src/.markdownlint.json src/
+
   unit_test:
     <<: *defaults
     steps:
@@ -117,6 +130,9 @@ workflows:
           requires:
             - get_source
       - lint_source:
+          requires:
+            - get_source
+      - lint_markdown:
           requires:
             - get_source
       - unit_test:

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "default": true,
+    "MD013": false
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # SCS Key Client
 
+[![GoDoc](https://godoc.org/github.com/sylabs/scs-key-client?status.svg)](https://godoc.org/github.com/sylabs/scs-key-client)
 [![Build Status](https://circleci.com/gh/sylabs/scs-key-client.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/scs-key-client)
 
 This project provides a Go client for the Singularity Container Services (SCS) Key Service.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SCS Key Client
 
-<a href="https://circleci.com/gh/sylabs/workflows/scs-key-client"><img src="https://circleci.com/gh/sylabs/scs-key-client.svg?style=shield&circle-token=f2b6e1b11393ccadf9ec8712d76da4a48dc8630d"></a>
+[![Build Status](https://circleci.com/gh/sylabs/scs-key-client.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/scs-key-client)
 
 This project provides a Go client for the Singularity Container Services (SCS) Key Service.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GoDoc](https://godoc.org/github.com/sylabs/scs-key-client?status.svg)](https://godoc.org/github.com/sylabs/scs-key-client)
 [![Build Status](https://circleci.com/gh/sylabs/scs-key-client.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/scs-key-client)
+[![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/scs-key-client)](https://goreportcard.com/report/github.com/sylabs/scs-key-client)
 
 This project provides a Go client for the Singularity Container Services (SCS) Key Service.
 


### PR DESCRIPTION
Add `lint_markdown` job to CircleCI config. Fix `README` issues found by `markdownlint`. Add GoDoc and go report badges.