### PR TITLE
Improve PKS Errors

### DIFF
--- a/client/pks.go
+++ b/client/pks.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/sylabs/json-resp"
+	jsonresp "github.com/sylabs/json-resp"
 )
 
 const (
@@ -42,7 +42,10 @@ func (c *Client) PKSAdd(ctx context.Context, keyText string) error {
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return jsonresp.NewError(res.StatusCode, res.Status)
+		if err := jsonresp.ReadError(res.Body); err != nil {
+			return err
+		}
+		return jsonresp.NewError(res.StatusCode, "")
 	}
 	return nil
 }
@@ -89,7 +92,10 @@ func (c *Client) PKSLookup(ctx context.Context, pd *PageDetails, search, operati
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return "", jsonresp.NewError(res.StatusCode, res.Status)
+		if err := jsonresp.ReadError(res.Body); err != nil {
+			return "", err
+		}
+		return "", jsonresp.NewError(res.StatusCode, "")
 	}
 
 	if pd != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/sylabs/scs-key-client
 
 go 1.12
 
-require github.com/sylabs/json-resp v0.3.0
+require github.com/sylabs/json-resp v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/sylabs/json-resp v0.3.0 h1:mmcJxb99UzWNRNnGnHRwCFfCVb/OySp+P5LOL5Dj9s8=
-github.com/sylabs/json-resp v0.3.0/go.mod h1:7wQKZe2aMscWOOpeGqQVPb6+nU5uEQqqV+NydXjyozE=
+github.com/sylabs/json-resp v0.5.0 h1:AWdKu6aS0WrkkltX1M0ex0lENrIcx5TISox902s2L2M=
+github.com/sylabs/json-resp v0.5.0/go.mod h1:anCzED2SGHHZQDubMuoVtwMuJZdpqQ+7iso8yDFm/nQ=


### PR DESCRIPTION
Update `json-resp` to `v0.5.0`. Use new `func jsonresp.ReadError` in PKS functions for higher fidelity errors.

Closes #7