### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,20 @@ jobs:
           name: Run Tests
           command: go test -cover -race -timeout 60s ./...
 
-  get_source:
+  lint_markdown:
+    <<: *defaults
+    docker:
+      - image: node:11-slim
+    steps:
+      - checkout
+      - run:
+          name: Install markdownlint
+          command: npm install -g markdownlint-cli
+      - run:
+          name: Check for Lint
+          command: markdownlint .
+
+  cache_go_mod:
     <<: *defaults
     steps:
       - checkout
@@ -37,25 +50,19 @@ jobs:
             - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Populate Go Mod Cache
-          command: |
-            if [ ! -d /go/pkg/mod ]; then
-              go mod download
-            fi
+          command: go mod download
       - save_cache:
           key: go-mod-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
-      - persist_to_workspace:
-          root: /
-          paths:
-            - go/pkg/mod/*
-            - src/*
 
   build_source:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Build Source
           command: go build ./...
@@ -63,8 +70,10 @@ jobs:
   check_formatting:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Check Formatting
           command: test -z $(go fmt ./...)
@@ -72,8 +81,10 @@ jobs:
   vet_source:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Vet Source
           command: go vet -all ./...
@@ -81,8 +92,10 @@ jobs:
   lint_source:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Install golangci-lint
           command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
@@ -90,25 +103,13 @@ jobs:
           name: Check for Lint
           command: golangci-lint run ./...
 
-  lint_markdown:
-    <<: *defaults
-    docker:
-      - image: node:11-slim
-    steps:
-      - attach_workspace:
-          at: /
-      - run:
-          name: Install markdownlint
-          command: npm install -g markdownlint-cli
-      - run:
-          name: Check for Lint
-          command: markdownlint .
-
   unit_test:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Run Tests
           command: go test -cover -race -timeout 60s ./...
@@ -118,22 +119,20 @@ workflows:
 
   build_and_test:
     jobs:
-      - get_source
+      - lint_markdown
+      - cache_go_mod
       - build_source:
           requires:
-            - get_source
+            - cache_go_mod
       - check_formatting:
           requires:
-            - get_source
+            - cache_go_mod
       - vet_source:
           requires:
-            - get_source
+            - cache_go_mod
       - lint_source:
           requires:
-            - get_source
-      - lint_markdown:
-          requires:
-            - get_source
+            - cache_go_mod
       - unit_test:
           requires:
-            - get_source
+            - cache_go_mod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,17 +91,18 @@ jobs:
           command: golangci-lint run ./...
 
   lint_markdown:
+    <<: *defaults
     docker:
-      - image: circleci/ruby:2.4.1-node
+      - image: node:11-slim
     steps:
       - attach_workspace:
-          at: .
+          at: /
       - run:
           name: Install markdownlint
-          command: sudo npm install -g markdownlint-cli
+          command: npm install -g markdownlint-cli
       - run:
           name: Check for Lint
-          command: markdownlint --config src/.markdownlint.json src/
+          command: markdownlint .
 
   unit_test:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Check for Lint
           command: |
-            curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+            curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
             golangci-lint run ./...
       - run:
           name: Run Tests
@@ -85,7 +85,7 @@ jobs:
           at: /
       - run:
           name: Install golangci-lint
-          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
       - run:
           name: Check for Lint
           command: golangci-lint run ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
             - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Build Source
-          command: go build ./...
+          command: go build -mod=readonly ./...
 
   check_formatting:
     <<: *defaults

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.lintTool": "golangci-lint"
+}


### PR DESCRIPTION
Replace workspace usage with `checkout`/`restore_cache` as recommended on the [CircleCI blog](https://circleci.com/blog/deep-diving-into-circleci-workspaces/). This allows `lint_markdown` to start right away, which results in better utilization of our 4x concurrency limit. Visually, the new workflow:

<img width="468" alt="Screen Shot 2019-04-14 at 5 43 18 PM" src="https://user-images.githubusercontent.com/9903835/56099590-e6d44d80-5edc-11e9-8b08-9244910aa3c9.png">

Use `node:11-slim` (148MB) instead of `circleci/ruby:2.4.1-node` (960MB) for `lint_markdown` job. Update `golangci-lint` to v1.16. Add `-mod=readonly` to `build_source` job to verify `go.mod` is in sync with source code. Add `.vscode/settings.json` to set `go.lintTool` to `golangci-lint`.