### PR TITLE
Update to Go v1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Install golangci-lint
-          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
       - run:
           name: Check for Lint
           command: golangci-lint run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,28 +22,10 @@ jobs:
           name: Check for Lint
           command: markdownlint .
 
-  cache_go_mod:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
-      - run:
-          name: Populate Go Mod Cache
-          command: go mod download
-      - save_cache:
-          key: go-mod-{{ checksum "go.sum" }}
-          paths:
-            - '/go/pkg/mod'
-
   build_source:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Build Source
           command: go build -mod=readonly ./...
@@ -52,9 +34,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Install golangci-lint
           command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
@@ -66,9 +45,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Run Tests
           command: go test -coverprofile cover.out -race ./...
@@ -81,13 +57,6 @@ workflows:
   build_and_test:
     jobs:
       - lint_markdown
-      - cache_go_mod
-      - build_source:
-          requires:
-            - cache_go_mod
-      - lint_source:
-          requires:
-            - cache_go_mod
-      - unit_test:
-          requires:
-            - cache_go_mod
+      - build_source
+      - lint_source
+      - unit_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 defaults: &defaults
   working_directory: /src
   docker:
-    - image: golang:1.12
+    - image: golang:1.13
 
 jobs:
   lint_markdown:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable-all: true
   disable:
+    - funlen
     - gochecknoglobals
     - lll
     - scopelint

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sylabs/scs-key-client
 
-go 1.12
+go 1.13
 
 require github.com/sylabs/json-resp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/sylabs/scs-key-client
 
 go 1.12
 
-require github.com/sylabs/json-resp v0.5.0
+require github.com/sylabs/json-resp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/sylabs/json-resp v0.5.0 h1:AWdKu6aS0WrkkltX1M0ex0lENrIcx5TISox902s2L2M=
-github.com/sylabs/json-resp v0.5.0/go.mod h1:anCzED2SGHHZQDubMuoVtwMuJZdpqQ+7iso8yDFm/nQ=
+github.com/sylabs/json-resp v0.6.0 h1:W/yxwBu6WPMqiU9YBaelUsfWU1ZD+x4f4rxqmTr0LaI=
+github.com/sylabs/json-resp v0.6.0/go.mod h1:QYGGBTYDgiIH+c6zRQuVd4PIYfm//vFD2flnIdF1k7E=


### PR DESCRIPTION
Update to use Go v1.13. Update `github.com/sylabs/json-resp` dependency to v0.6.0. Update `golangci-lint` to v1.18.0. Update `codecov` Orb to v1.0.5 version. Remove `cache_go_mod` CI job.

Closes #18 