### PR TITLE
Fix TLS Check

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -108,7 +108,7 @@ func NewClient(cfg *Config) (c *Client, err error) {
 	}
 
 	// If auth token is used, verify TLS.
-	if cfg.AuthToken != "" && baseURL.Scheme != schemeHTTPS && baseURL.Host != "localhost" {
+	if cfg.AuthToken != "" && baseURL.Scheme != schemeHTTPS && baseURL.Hostname() != "localhost" {
 		return nil, ErrTLSRequired
 	}
 
@@ -140,7 +140,7 @@ func (c *Client) newRequest(method, path, rawQuery string, body io.Reader) (r *h
 	}
 
 	// If auth token is used, verify TLS.
-	if c.AuthToken != "" && u.Scheme != schemeHTTPS && u.Host != "localhost" {
+	if c.AuthToken != "" && u.Scheme != schemeHTTPS && u.Hostname() != "localhost" {
 		return nil, ErrTLSRequired
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -39,6 +39,18 @@ func TestNewClient(t *testing.T) {
 			BaseURL:   "hkp://pool.sks-keyservers.net",
 			AuthToken: "blah",
 		}, true, "", "", "", nil},
+		{"LocalhostAuthTokenHTTP", &Config{
+			BaseURL:   "http://localhost",
+			AuthToken: "blah",
+		}, false, "http://localhost", "blah", "", http.DefaultClient},
+		{"LocalhostAuthTokenHTTP8080", &Config{
+			BaseURL:   "http://localhost:8080",
+			AuthToken: "blah",
+		}, false, "http://localhost:8080", "blah", "", http.DefaultClient},
+		{"LocalhostAuthTokenHKP", &Config{
+			BaseURL:   "hkp://localhost",
+			AuthToken: "blah",
+		}, false, "http://localhost:11371", "blah", "", http.DefaultClient},
 		{"NilConfig", nil, false, defaultBaseURL, "", "", http.DefaultClient},
 		{"HTTPBaseURL", &Config{
 			BaseURL: "http://p80.pool.sks-keyservers.net",
@@ -97,6 +109,18 @@ func TestNewRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	httpLocalhostURL, err := url.Parse("http://localhost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	http8080LocalhostURL, err := url.Parse("http://localhost:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hkpLocalhostURL, err := url.Parse("hkp://localhost")
+	if err != nil {
+		t.Fatal(err)
+	}
 	httpURL, err := url.Parse("http://p80.pool.sks-keyservers.net")
 	if err != nil {
 		t.Fatal(err)
@@ -135,6 +159,18 @@ func TestNewRequest(t *testing.T) {
 			BaseURL:   hkpURL,
 			AuthToken: "blah",
 		}, http.MethodGet, "/path", "", "", true, "", "", ""},
+		{"LocalhostAuthTokenHTTP", &Client{
+			BaseURL:   httpLocalhostURL,
+			AuthToken: "blah",
+		}, http.MethodGet, "/path", "", "", false, "http://localhost/path", "BEARER blah", ""},
+		{"LocalhostAuthTokenHTTP8080", &Client{
+			BaseURL:   http8080LocalhostURL,
+			AuthToken: "blah",
+		}, http.MethodGet, "/path", "", "", false, "http://localhost:8080/path", "BEARER blah", ""},
+		{"LocalhostAuthTokenHKP", &Client{
+			BaseURL:   hkpLocalhostURL,
+			AuthToken: "blah",
+		}, http.MethodGet, "/path", "", "", false, "http://localhost:11371/path", "BEARER blah", ""},
 		{"Get", defaultClient, http.MethodGet, "/path", "", "", false, "https://keys.sylabs.io/path", "", ""},
 		{"Post", defaultClient, http.MethodPost, "/path", "", "", false, "https://keys.sylabs.io/path", "", ""},
 		{"PostRawQuery", defaultClient, http.MethodPost, "/path", "a=b", "", false, "https://keys.sylabs.io/path?a=b", "", ""},


### PR DESCRIPTION
Fix case where TLS check would report an error if the normalized URI contained a port number. Add test cases to exercise.

Fixes #24 