### PR TITLE
Fix BaseURL Path Handling

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const (
@@ -85,7 +86,7 @@ func normalizeURL(u *url.URL) (*url.URL, error) {
 	}
 }
 
-const defaultBaseURL = "https://keys.sylabs.io"
+const defaultBaseURL = "https://keys.sylabs.io/"
 
 // NewClient sets up a new Key Service client with the specified base URL and auth token.
 func NewClient(cfg *Config) (c *Client, err error) {
@@ -105,6 +106,12 @@ func NewClient(cfg *Config) (c *Client, err error) {
 	baseURL, err = normalizeURL(baseURL)
 	if err != nil {
 		return nil, err
+	}
+
+	// Ensure path is terminated with a separator, to prevent url.ResolveReference from stripping
+	// the final path component of BaseURL when constructing request URL from a relative path.
+	if !strings.HasSuffix(baseURL.Path, "/") {
+		baseURL.Path += "/"
 	}
 
 	// If auth token is used, verify TLS.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -77,19 +77,28 @@ func TestNewClient(t *testing.T) {
 		{"LocalhostAuthTokenHTTP", &Config{
 			BaseURL:   "http://localhost",
 			AuthToken: "blah",
-		}, false, "http://localhost", "blah", "", http.DefaultClient},
+		}, false, "http://localhost/", "blah", "", http.DefaultClient},
 		{"LocalhostAuthTokenHTTP8080", &Config{
 			BaseURL:   "http://localhost:8080",
 			AuthToken: "blah",
-		}, false, "http://localhost:8080", "blah", "", http.DefaultClient},
+		}, false, "http://localhost:8080/", "blah", "", http.DefaultClient},
 		{"LocalhostAuthTokenHKP", &Config{
 			BaseURL:   "hkp://localhost",
 			AuthToken: "blah",
-		}, false, "http://localhost:11371", "blah", "", http.DefaultClient},
+		}, false, "http://localhost:11371/", "blah", "", http.DefaultClient},
 		{"NilConfig", nil, false, defaultBaseURL, "", "", http.DefaultClient},
 		{"BaseURL", &Config{
 			BaseURL: "hkps://hkps.pool.sks-keyservers.net",
-		}, false, "https://hkps.pool.sks-keyservers.net", "", "", http.DefaultClient},
+		}, false, "https://hkps.pool.sks-keyservers.net/", "", "", http.DefaultClient},
+		{"BaseURLSlash", &Config{
+			BaseURL: "hkps://hkps.pool.sks-keyservers.net/",
+		}, false, "https://hkps.pool.sks-keyservers.net/", "", "", http.DefaultClient},
+		{"BaseURLWithPath", &Config{
+			BaseURL: "hkps://hkps.pool.sks-keyservers.net/path",
+		}, false, "https://hkps.pool.sks-keyservers.net/path/", "", "", http.DefaultClient},
+		{"BaseURLWithPathSlash", &Config{
+			BaseURL: "hkps://hkps.pool.sks-keyservers.net/path/",
+		}, false, "https://hkps.pool.sks-keyservers.net/path/", "", "", http.DefaultClient},
 		{"AuthToken", &Config{
 			AuthToken: "blah",
 		}, false, defaultBaseURL, "blah", "", http.DefaultClient},

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,9 +9,44 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     *url.URL
+		wantErr bool
+		wantURL *url.URL
+	}{
+		{"BadScheme", &url.URL{Scheme: "bad"}, true, nil},
+		{"HTTPBaseURL", &url.URL{Scheme: "http", Host: "p80.pool.sks-keyservers.net"},
+			false, &url.URL{Scheme: "http", Host: "p80.pool.sks-keyservers.net"}},
+		{"HTTPSBaseURL", &url.URL{Scheme: "https", Host: "hkps.pool.sks-keyservers.net"},
+			false, &url.URL{Scheme: "https", Host: "hkps.pool.sks-keyservers.net"}},
+		{"HKPBaseURL", &url.URL{Scheme: "hkp", Host: "pool.sks-keyservers.net"},
+			false, &url.URL{Scheme: "http", Host: "pool.sks-keyservers.net:11371"}},
+		{"HKPSBaseURL", &url.URL{Scheme: "hkps", Host: "hkps.pool.sks-keyservers.net"},
+			false, &url.URL{Scheme: "https", Host: "hkps.pool.sks-keyservers.net"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := normalizeURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("got err %v, want %v", err, tt.wantErr)
+			}
+
+			if err == nil {
+				if got, want := u, tt.wantURL; !reflect.DeepEqual(got, want) {
+					t.Errorf("got url %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}
 
 func TestNewClient(t *testing.T) {
 	httpClient := &http.Client{}
@@ -52,16 +87,7 @@ func TestNewClient(t *testing.T) {
 			AuthToken: "blah",
 		}, false, "http://localhost:11371", "blah", "", http.DefaultClient},
 		{"NilConfig", nil, false, defaultBaseURL, "", "", http.DefaultClient},
-		{"HTTPBaseURL", &Config{
-			BaseURL: "http://p80.pool.sks-keyservers.net",
-		}, false, "http://p80.pool.sks-keyservers.net", "", "", http.DefaultClient},
-		{"HTTPSBaseURL", &Config{
-			BaseURL: "https://hkps.pool.sks-keyservers.net",
-		}, false, "https://hkps.pool.sks-keyservers.net", "", "", http.DefaultClient},
-		{"HKPBaseURL", &Config{
-			BaseURL: "hkp://pool.sks-keyservers.net",
-		}, false, "http://pool.sks-keyservers.net:11371", "", "", http.DefaultClient},
-		{"HKPSBaseURL", &Config{
+		{"BaseURL", &Config{
 			BaseURL: "hkps://hkps.pool.sks-keyservers.net",
 		}, false, "https://hkps.pool.sks-keyservers.net", "", "", http.DefaultClient},
 		{"AuthToken", &Config{
@@ -109,35 +135,6 @@ func TestNewRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	httpLocalhostURL, err := url.Parse("http://localhost")
-	if err != nil {
-		t.Fatal(err)
-	}
-	http8080LocalhostURL, err := url.Parse("http://localhost:8080")
-	if err != nil {
-		t.Fatal(err)
-	}
-	hkpLocalhostURL, err := url.Parse("hkp://localhost")
-	if err != nil {
-		t.Fatal(err)
-	}
-	httpURL, err := url.Parse("http://p80.pool.sks-keyservers.net")
-	if err != nil {
-		t.Fatal(err)
-	}
-	httpsURL, err := url.Parse("https://hkps.pool.sks-keyservers.net")
-	if err != nil {
-		t.Fatal(err)
-	}
-	hkpURL, err := url.Parse("hkp://pool.sks-keyservers.net")
-	if err != nil {
-		t.Fatal(err)
-	}
-	hkpsURL, err := url.Parse("hkps://hkps.pool.sks-keyservers.net")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	tests := []struct {
 		name           string
 		client         *Client
@@ -151,41 +148,35 @@ func TestNewRequest(t *testing.T) {
 		wantUserAgent  string
 	}{
 		{"BadMethod", defaultClient, "b@d	", "", "", "", true, "", "", ""},
+		{"BadScheme", &Client{
+			BaseURL: &url.URL{Scheme: "bad", Host: "localhost"},
+		}, http.MethodGet, "/path", "", "", true, "", "", ""},
 		{"TLSRequiredHTTP", &Client{
-			BaseURL:   httpURL,
+			BaseURL:   &url.URL{Scheme: "http", Host: "p80.pool.sks-keyservers.net"},
 			AuthToken: "blah",
 		}, "", "", "", "", true, "", "", ""},
 		{"TLSRequiredHKP", &Client{
-			BaseURL:   hkpURL,
+			BaseURL:   &url.URL{Scheme: "hkp", Host: "pool.sks-keyservers.net"},
 			AuthToken: "blah",
 		}, http.MethodGet, "/path", "", "", true, "", "", ""},
 		{"LocalhostAuthTokenHTTP", &Client{
-			BaseURL:   httpLocalhostURL,
+			BaseURL:   &url.URL{Scheme: "http", Host: "localhost"},
 			AuthToken: "blah",
 		}, http.MethodGet, "/path", "", "", false, "http://localhost/path", "BEARER blah", ""},
 		{"LocalhostAuthTokenHTTP8080", &Client{
-			BaseURL:   http8080LocalhostURL,
+			BaseURL:   &url.URL{Scheme: "http", Host: "localhost:8080"},
 			AuthToken: "blah",
 		}, http.MethodGet, "/path", "", "", false, "http://localhost:8080/path", "BEARER blah", ""},
 		{"LocalhostAuthTokenHKP", &Client{
-			BaseURL:   hkpLocalhostURL,
+			BaseURL:   &url.URL{Scheme: "hkp", Host: "localhost"},
 			AuthToken: "blah",
 		}, http.MethodGet, "/path", "", "", false, "http://localhost:11371/path", "BEARER blah", ""},
 		{"Get", defaultClient, http.MethodGet, "/path", "", "", false, "https://keys.sylabs.io/path", "", ""},
 		{"Post", defaultClient, http.MethodPost, "/path", "", "", false, "https://keys.sylabs.io/path", "", ""},
 		{"PostRawQuery", defaultClient, http.MethodPost, "/path", "a=b", "", false, "https://keys.sylabs.io/path?a=b", "", ""},
 		{"PostBody", defaultClient, http.MethodPost, "/path", "", "body", false, "https://keys.sylabs.io/path", "", ""},
-		{"HTTPBaseURL", &Client{
-			BaseURL: httpURL,
-		}, http.MethodGet, "/path", "", "", false, "http://p80.pool.sks-keyservers.net/path", "", ""},
-		{"HTTPSBaseURL", &Client{
-			BaseURL: httpsURL,
-		}, http.MethodGet, "/path", "", "", false, "https://hkps.pool.sks-keyservers.net/path", "", ""},
-		{"HKPBaseURL", &Client{
-			BaseURL: hkpURL,
-		}, http.MethodGet, "/path", "", "", false, "http://pool.sks-keyservers.net:11371/path", "", ""},
-		{"HKPSBaseURL", &Client{
-			BaseURL: hkpsURL,
+		{"BaseURL", &Client{
+			BaseURL: &url.URL{Scheme: "hkps", Host: "hkps.pool.sks-keyservers.net"},
 		}, http.MethodGet, "/path", "", "", false, "https://hkps.pool.sks-keyservers.net/path", "", ""},
 		{"AuthToken", &Client{
 			BaseURL:   defaultClient.BaseURL,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -175,9 +175,24 @@ func TestNewRequest(t *testing.T) {
 		{"Post", defaultClient, http.MethodPost, "/path", "", "", false, "https://keys.sylabs.io/path", "", ""},
 		{"PostRawQuery", defaultClient, http.MethodPost, "/path", "a=b", "", false, "https://keys.sylabs.io/path?a=b", "", ""},
 		{"PostBody", defaultClient, http.MethodPost, "/path", "", "body", false, "https://keys.sylabs.io/path", "", ""},
-		{"BaseURL", &Client{
+		{"BaseURLAbsolute", &Client{
 			BaseURL: &url.URL{Scheme: "hkps", Host: "hkps.pool.sks-keyservers.net"},
 		}, http.MethodGet, "/path", "", "", false, "https://hkps.pool.sks-keyservers.net/path", "", ""},
+		{"BaseURLRelative", &Client{
+			BaseURL: &url.URL{Scheme: "hkps", Host: "hkps.pool.sks-keyservers.net"},
+		}, http.MethodGet, "path", "", "", false, "https://hkps.pool.sks-keyservers.net/path", "", ""},
+		{"BaseURLPathAbsolute", &Client{
+			BaseURL: &url.URL{Scheme: "hkps", Host: "hkps.pool.sks-keyservers.net", Path: "/a/b"},
+		}, http.MethodGet, "/path", "", "", false, "https://hkps.pool.sks-keyservers.net/path", "", ""},
+		{"BaseURLPathRelative", &Client{
+			BaseURL: &url.URL{Scheme: "hkps", Host: "hkps.pool.sks-keyservers.net", Path: "/a/b"},
+		}, http.MethodGet, "path", "", "", false, "https://hkps.pool.sks-keyservers.net/a/path", "", ""},
+		{"BaseURLPathSlashAbsolute", &Client{
+			BaseURL: &url.URL{Scheme: "hkps", Host: "hkps.pool.sks-keyservers.net", Path: "/a/b/"},
+		}, http.MethodGet, "/path", "", "", false, "https://hkps.pool.sks-keyservers.net/path", "", ""},
+		{"BaseURLPathSlashRelative", &Client{
+			BaseURL: &url.URL{Scheme: "hkps", Host: "hkps.pool.sks-keyservers.net", Path: "/a/b/"},
+		}, http.MethodGet, "path", "", "", false, "https://hkps.pool.sks-keyservers.net/a/b/path", "", ""},
 		{"AuthToken", &Client{
 			BaseURL:   defaultClient.BaseURL,
 			AuthToken: "blah",

--- a/client/pks_test.go
+++ b/client/pks_test.go
@@ -68,6 +68,7 @@ func TestPKSAdd(t *testing.T) {
 		message string
 	}{
 		{"Success", s.URL, "key", http.StatusOK, ""},
+		{"SuccessPath", s.URL + "/path", "key", http.StatusOK, ""},
 		{"Error", s.URL, "key", http.StatusBadRequest, ""},
 		{"ErrorMessage", s.URL, "key", http.StatusBadRequest, "blah"},
 		{"BadURL", "http://127.0.0.1:123456", "key", 0, ""},
@@ -265,6 +266,7 @@ func TestPKSLookup(t *testing.T) {
 		{"VIndexMachineReadableBlah", s.URL, http.StatusOK, "", "search", OperationVIndex, []string{OptionMachineReadable, "blah"}, false, false, "", 0, ""},
 		{"VIndexFingerprint", s.URL, http.StatusOK, "", "search", OperationVIndex, []string{}, true, false, "", 0, ""},
 		{"VIndexExact", s.URL, http.StatusOK, "", "search", OperationVIndex, []string{}, false, true, "", 0, ""},
+		{"BaseURLPath", s.URL + "/path", http.StatusOK, "", "search", OperationGet, []string{}, false, false, "", 0, ""},
 		{"Error", s.URL, http.StatusBadRequest, "", "search", OperationGet, []string{}, false, false, "", 0, ""},
 		{"ErrorMessage", s.URL, http.StatusBadRequest, "blah", "search", OperationGet, []string{}, false, false, "", 0, ""},
 		{"BadURL", "http://127.0.0.1:123456", 0, "", "search", OperationGet, []string{}, false, false, "", 0, ""},
@@ -357,6 +359,7 @@ func TestGetKey(t *testing.T) {
 		{"KeyID", s.URL, http.StatusOK, "", search[len(search)-8:]},
 		{"V3Fingerprint", s.URL, http.StatusOK, "", search[len(search)-16:]},
 		{"V4Fingerprint", s.URL, http.StatusOK, "", search},
+		{"BaseURLPath", s.URL + "/path", http.StatusOK, "", search},
 		{"Error", s.URL, http.StatusBadRequest, "", search},
 		{"ErrorMessage", s.URL, http.StatusBadRequest, "blah", search},
 		{"BadURL", "http://127.0.0.1:123456", 0, "", search},

--- a/client/version.go
+++ b/client/version.go
@@ -12,7 +12,7 @@ import (
 	jsonresp "github.com/sylabs/json-resp"
 )
 
-const pathVersion = "/version"
+const pathVersion = "version"
 
 // VersionInfo contains version information.
 type VersionInfo struct {


### PR DESCRIPTION
Fix `(*Client).GetVersion()` bug when a `(*Client).BaseURL` includes a path component. Re-factor unit tests.

Fixes #28 