### PR TITLE
Expose NewRequest

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -135,8 +135,9 @@ func NewClient(cfg *Config) (c *Client, err error) {
 	return c, nil
 }
 
-// newRequest returns a new Request given a method, path, query, and optional body.
-func (c *Client) newRequest(method, path, rawQuery string, body io.Reader) (r *http.Request, err error) {
+// NewRequest returns a new Request given a method, path, query, and optional body. The path may be
+// relative or absolute.
+func (c *Client) NewRequest(method, path, rawQuery string, body io.Reader) (r *http.Request, err error) {
 	u := c.BaseURL.ResolveReference(&url.URL{
 		Path:     path,
 		RawQuery: rawQuery,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -214,7 +214,7 @@ func TestNewRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r, err := tt.client.newRequest(tt.method, tt.path, tt.rawQuery, strings.NewReader(tt.body))
+			r, err := tt.client.NewRequest(tt.method, tt.path, tt.rawQuery, strings.NewReader(tt.body))
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("got err %v, wantErr %v", err, tt.wantErr)
 			}

--- a/client/pks.go
+++ b/client/pks.go
@@ -43,7 +43,7 @@ func (c *Client) PKSAdd(ctx context.Context, keyText string) error {
 	v := url.Values{}
 	v.Set("keytext", keyText)
 
-	req, err := c.newRequest(http.MethodPost, pathPKSAdd, "", strings.NewReader(v.Encode()))
+	req, err := c.NewRequest(http.MethodPost, pathPKSAdd, "", strings.NewReader(v.Encode()))
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (c *Client) PKSLookup(ctx context.Context, pd *PageDetails, search, operati
 		}
 	}
 
-	req, err := c.newRequest(http.MethodGet, pathPKSLookup, v.Encode(), nil)
+	req, err := c.NewRequest(http.MethodGet, pathPKSLookup, v.Encode(), nil)
 	if err != nil {
 		return "", err
 	}

--- a/client/version.go
+++ b/client/version.go
@@ -22,7 +22,7 @@ type VersionInfo struct {
 // GetVersion gets version information from the Key Service. The context controls the lifetime of
 // the request.
 func (c *Client) GetVersion(ctx context.Context) (vi VersionInfo, err error) {
-	req, err := c.newRequest(http.MethodGet, pathVersion, "", nil)
+	req, err := c.NewRequest(http.MethodGet, pathVersion, "", nil)
 	if err != nil {
 		return VersionInfo{}, err
 	}


### PR DESCRIPTION
Expose `(*Client).NewRequest()`, for use in modules that wrap this client to extend it.