### PR TITLE
Fix Dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://circleci.com/gh/sylabs/scs-key-client.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/scs-key-client)
 [![Code Coverage](https://codecov.io/gh/sylabs/scs-key-client/branch/master/graph/badge.svg)](https://codecov.io/gh/sylabs/scs-key-client)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/scs-key-client)](https://goreportcard.com/report/github.com/sylabs/scs-key-client)
-[![Dependabot](https://api.dependabot.com/badges/status?host=github&repo=sylabs/scs-key-client)](https://app.dependabot.com/accounts/sylabs/repos/172931061)
+[![Dependabot](https://flat.badgen.net/dependabot/sylabs/scs-key-client?icon=dependabot)](https://github.com/sylabs/scs-key-client/network/updates)
 
 This project provides a Go client for the Singularity Container Services (SCS) Key Service.
 


### PR DESCRIPTION
Update Dependabot badge following migration to GitHub-native Dependabot (#35).

Using https://badgen.net for the badge asset itself, as I couldn't find a source for this from GitHub directly.