### PR TITLE
Bump Go to 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:14-slim
   golang:
     docker:
-      - image: golang:1.14
+      - image: golang:1.15
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.30-alpine

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sylabs/scs-key-client
 
-go 1.13
+go 1.14
 
 require github.com/sylabs/json-resp v0.7.0


### PR DESCRIPTION
Upgrade Go to 1.15, and ratchet language version to 1.14 (implying support for two latest versions of Go.)