### PR TITLE
Refactor

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -70,38 +70,38 @@ type clientOptions struct {
 	httpClient  *http.Client
 }
 
-// Option are used to configure c.
-type Option func(c *clientOptions) error
+// Option are used to populate co.
+type Option func(co *clientOptions) error
 
 // OptBaseURL sets the base URL of the key server to url. The supported URL schemes are "http",
 // "https", "hkp", and "hkps".
 func OptBaseURL(url string) Option {
-	return func(opts *clientOptions) error {
-		opts.baseURL = url
+	return func(co *clientOptions) error {
+		co.baseURL = url
 		return nil
 	}
 }
 
 // OptBearerToken sets the bearer token to include in the "Authorization" header of each request.
 func OptBearerToken(token string) Option {
-	return func(opts *clientOptions) error {
-		opts.bearerToken = token
+	return func(co *clientOptions) error {
+		co.bearerToken = token
 		return nil
 	}
 }
 
 // OptUserAgent sets the HTTP user agent to include in the "User-Agent" header of each request.
 func OptUserAgent(agent string) Option {
-	return func(opts *clientOptions) error {
-		opts.userAgent = agent
+	return func(co *clientOptions) error {
+		co.userAgent = agent
 		return nil
 	}
 }
 
 // OptHTTPClient sets the client to use to make HTTP requests.
 func OptHTTPClient(c *http.Client) Option {
-	return func(opts *clientOptions) error {
-		opts.httpClient = c
+	return func(co *clientOptions) error {
+		co.httpClient = c
 		return nil
 	}
 }

--- a/client/error.go
+++ b/client/error.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
+// distributed with the sources of this project regarding your rights to use or distribute this
+// software.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	jsonresp "github.com/sylabs/json-resp"
+)
+
+// HTTPError represents an error returned from an HTTP server.
+type HTTPError struct {
+	code int
+	err  error
+}
+
+// Code returns the HTTP status code associated with e.
+func (e *HTTPError) Code() int { return e.code }
+
+// Unwrap returns the error wrapped by e.
+func (e *HTTPError) Unwrap() error { return e.err }
+
+// Error returns a human-readable representation of e.
+func (e *HTTPError) Error() string {
+	if e.err != nil {
+		return fmt.Sprintf("%v %v: %v", e.code, http.StatusText(e.code), e.err.Error())
+	}
+	return fmt.Sprintf("%v %v", e.code, http.StatusText(e.code))
+}
+
+// Is compares e against target. If target is a HTTPError with the same code as e, true is returned.
+func (e *HTTPError) Is(target error) bool {
+	t, ok := target.(*HTTPError)
+	return ok && (t.code == e.code)
+}
+
+// errorFromResponse returns an HTTPError containing the status code and detailed error message (if
+// available) from res.
+func errorFromResponse(res *http.Response) error {
+	httpErr := HTTPError{code: res.StatusCode}
+
+	var jerr *jsonresp.Error
+	if err := jsonresp.ReadError(res.Body); errors.As(err, &jerr) {
+		httpErr.err = errors.New(jerr.Message)
+	}
+
+	return &httpErr
+}

--- a/client/error_test.go
+++ b/client/error_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
+// distributed with the sources of this project regarding your rights to use or distribute this
+// software.
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestHTTPError(t *testing.T) {
+	tests := []struct {
+		name        string
+		code        int
+		err         error
+		wantMessage string
+	}{
+		{
+			name:        "BadRequest",
+			code:        http.StatusBadRequest,
+			wantMessage: "400 Bad Request",
+		},
+		{
+			name:        "BadRequestWithMessage",
+			code:        http.StatusBadRequest,
+			err:         errors.New("more good needed"),
+			wantMessage: "400 Bad Request: more good needed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &HTTPError{
+				code: tt.code,
+				err:  tt.err,
+			}
+
+			if got, want := err.Code(), tt.code; got != want {
+				t.Errorf("got code %v, want %v", got, want)
+			}
+			if got, want := err.Unwrap(), tt.err; got != want {
+				t.Errorf("got unwrapped error %v, want %v", got, want)
+			}
+			if got, want := err.Error(), tt.wantMessage; got != want {
+				t.Errorf("got message %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/client/pks.go
+++ b/client/pks.go
@@ -57,7 +57,7 @@ func (c *Client) PKSAdd(ctx context.Context, keyText string) error {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode/100 != 2 { // non-2xx status code
 		return fmt.Errorf("%w", errorFromResponse(res))
 	}
 	return nil
@@ -129,7 +129,7 @@ func (c *Client) PKSLookup(ctx context.Context, pd *PageDetails, search, operati
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode/100 != 2 { // non-2xx status code
 		return "", fmt.Errorf("%w", errorFromResponse(res))
 	}
 

--- a/client/pks.go
+++ b/client/pks.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -14,8 +14,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-
-	jsonresp "github.com/sylabs/json-resp"
 )
 
 const (
@@ -23,45 +21,54 @@ const (
 	pathPKSLookup = "/pks/lookup"
 )
 
-var (
-	// ErrInvalidKeyText is returned when the key text is invalid.
-	ErrInvalidKeyText = errors.New("invalid key text")
-	// ErrInvalidSearch is returned when the search value is invalid.
-	ErrInvalidSearch = errors.New("invalid search")
-	// ErrInvalidOperation is returned when the operation is invalid.
-	ErrInvalidOperation = errors.New("invalid operation")
-)
+// ErrInvalidKeyText is returned when the key text is invalid.
+var ErrInvalidKeyText = errors.New("invalid key text")
+
+// ErrInvalidSearch is returned when the search value is invalid.
+var ErrInvalidSearch = errors.New("invalid search")
+
+// ErrInvalidOperation is returned when the operation is invalid.
+var ErrInvalidOperation = errors.New("invalid operation")
 
 // PKSAdd submits an ASCII armored keyring to the Key Service, as specified in section 4 of the
 // OpenPGP HTTP Keyserver Protocol (HKP) specification. The context controls the lifetime of the
 // request.
+//
+// If an non-200 HTTP status code is received, an error wrapping an HTTPError is returned.
 func (c *Client) PKSAdd(ctx context.Context, keyText string) error {
 	if keyText == "" {
-		return ErrInvalidKeyText
+		return fmt.Errorf("%w", ErrInvalidKeyText)
 	}
+
+	ref := &url.URL{Path: pathPKSAdd}
 
 	v := url.Values{}
 	v.Set("keytext", keyText)
 
-	req, err := c.NewRequest(http.MethodPost, pathPKSAdd, "", strings.NewReader(v.Encode()))
+	req, err := c.NewRequest(ctx, http.MethodPost, ref, strings.NewReader(v.Encode()))
 	if err != nil {
-		return err
+		return fmt.Errorf("%w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w", err)
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		if err := jsonresp.ReadError(res.Body); err != nil {
-			return err
-		}
-		return jsonresp.NewError(res.StatusCode, "")
+		return fmt.Errorf("%w", errorFromResponse(res))
 	}
 	return nil
+}
+
+// PageDetails includes pagination details.
+type PageDetails struct {
+	// Maximum number of results per page (server may ignore or return fewer).
+	Size int
+	// Token for next page (advanced with each request, empty for last page).
+	Token string
 }
 
 const (
@@ -78,12 +85,14 @@ const OptionMachineReadable = "mr"
 
 // PKSLookup requests data from the Key Service, as specified in section 3 of the OpenPGP HTTP
 // Keyserver Protocol (HKP) specification. The context controls the lifetime of the request.
+//
+// If an non-200 HTTP status code is received, an error wrapping an HTTPError is returned.
 func (c *Client) PKSLookup(ctx context.Context, pd *PageDetails, search, operation string, fingerprint, exact bool, options []string) (response string, err error) {
 	if search == "" {
-		return "", ErrInvalidSearch
+		return "", fmt.Errorf("%w", ErrInvalidSearch)
 	}
 	if operation == "" {
-		return "", ErrInvalidOperation
+		return "", fmt.Errorf("%w", ErrInvalidOperation)
 	}
 
 	v := url.Values{}
@@ -107,22 +116,21 @@ func (c *Client) PKSLookup(ctx context.Context, pd *PageDetails, search, operati
 		}
 	}
 
-	req, err := c.NewRequest(http.MethodGet, pathPKSLookup, v.Encode(), nil)
+	ref := &url.URL{Path: pathPKSLookup, RawQuery: v.Encode()}
+
+	req, err := c.NewRequest(ctx, http.MethodGet, ref, nil)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%w", err)
 	}
 
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.Do(req)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%w", err)
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		if err := jsonresp.ReadError(res.Body); err != nil {
-			return "", err
-		}
-		return "", jsonresp.NewError(res.StatusCode, "")
+		return "", fmt.Errorf("%w", errorFromResponse(res))
 	}
 
 	if pd != nil {
@@ -131,7 +139,7 @@ func (c *Client) PKSLookup(ctx context.Context, pd *PageDetails, search, operati
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%w", err)
 	}
 	return string(body), nil
 }
@@ -139,11 +147,13 @@ func (c *Client) PKSLookup(ctx context.Context, pd *PageDetails, search, operati
 // GetKey retrieves an ASCII armored keyring matching search from the Key Service. A 32-bit key ID,
 // 64-bit key ID, 128-bit version 3 fingerprint, or 160-bit version 4 fingerprint can be specified
 // in search. The context controls the lifetime of the request.
+//
+// If an non-200 HTTP status code is received, an error wrapping an HTTPError is returned.
 func (c *Client) GetKey(ctx context.Context, search []byte) (keyText string, err error) {
 	switch len(search) {
 	case 4, 8, 16, 20:
 		return c.PKSLookup(ctx, nil, fmt.Sprintf("%#x", search), OperationGet, false, true, nil)
 	default:
-		return "", ErrInvalidSearch
+		return "", fmt.Errorf("%w", ErrInvalidSearch)
 	}
 }

--- a/client/pks_test.go
+++ b/client/pks_test.go
@@ -27,7 +27,7 @@ type MockPKSAdd struct {
 }
 
 func (m *MockPKSAdd) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if m.code != http.StatusOK {
+	if m.code/100 != 2 { // non-2xx status code
 		if m.message != "" {
 			if err := jsonresp.WriteError(w, m.message, m.code); err != nil {
 				m.t.Fatalf("failed to write error: %v", err)
@@ -71,6 +71,12 @@ func TestPKSAdd(t *testing.T) {
 			ctx:     context.Background(),
 			keyText: "key",
 			code:    http.StatusOK,
+		},
+		{
+			name:    "Accepted",
+			ctx:     context.Background(),
+			keyText: "key",
+			code:    http.StatusAccepted,
 		},
 		{
 			name:    "HTTPError",
@@ -145,7 +151,7 @@ type MockPKSLookup struct {
 }
 
 func (m *MockPKSLookup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if m.code != http.StatusOK {
+	if m.code/100 != 2 { // non-2xx status code
 		if m.message != "" {
 			if err := jsonresp.WriteError(w, m.message, m.code); err != nil {
 				m.t.Fatalf("failed to write error: %v", err)
@@ -430,6 +436,13 @@ func TestPKSLookup(t *testing.T) {
 			exact:  true,
 		},
 		{
+			name:   "NonAuthoritativeInfo",
+			ctx:    context.Background(),
+			code:   http.StatusNonAuthoritativeInfo,
+			search: "search",
+			op:     OperationGet,
+		},
+		{
 			name:    "HTTPError",
 			ctx:     context.Background(),
 			code:    http.StatusBadRequest,
@@ -563,6 +576,12 @@ func TestGetKey(t *testing.T) {
 			name:   "V4Fingerprint",
 			ctx:    context.Background(),
 			code:   http.StatusOK,
+			search: search,
+		},
+		{
+			name:   "NonAuthoritativeInfo",
+			ctx:    context.Background(),
+			code:   http.StatusNonAuthoritativeInfo,
 			search: search,
 		},
 		{

--- a/client/pks_test.go
+++ b/client/pks_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -54,59 +55,75 @@ func (m *MockPKSAdd) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestPKSAdd(t *testing.T) {
-	m := &MockPKSAdd{
-		t: t,
-	}
-	s := httptest.NewServer(m)
-	defer s.Close()
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
 
 	tests := []struct {
 		name    string
-		baseURL string
+		ctx     context.Context
 		keyText string
 		code    int
 		message string
+		wantErr error
 	}{
-		{"Success", s.URL, "key", http.StatusOK, ""},
-		{"SuccessPath", s.URL + "/path", "key", http.StatusOK, ""},
-		{"Error", s.URL, "key", http.StatusBadRequest, ""},
-		{"ErrorMessage", s.URL, "key", http.StatusBadRequest, "blah"},
-		{"BadURL", "http://127.0.0.1:123456", "key", 0, ""},
-		{"InvalidKeyText", s.URL, "", 0, ""},
+		{
+			name:    "OK",
+			ctx:     context.Background(),
+			keyText: "key",
+			code:    http.StatusOK,
+		},
+		{
+			name:    "HTTPError",
+			ctx:     context.Background(),
+			keyText: "key",
+			code:    http.StatusBadRequest,
+			wantErr: &HTTPError{code: http.StatusBadRequest},
+		},
+		{
+			name:    "HTTPErrorMessage",
+			ctx:     context.Background(),
+			keyText: "key",
+			code:    http.StatusBadRequest,
+			message: "blah",
+			wantErr: &HTTPError{code: http.StatusBadRequest},
+		},
+		{
+			name:    "ContextCanceled",
+			ctx:     cancelled,
+			keyText: "key",
+			code:    http.StatusOK,
+			wantErr: context.Canceled,
+		},
+		{
+			name:    "InvalidKeyText",
+			ctx:     context.Background(),
+			keyText: "",
+			wantErr: ErrInvalidKeyText,
+		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			m.code = tt.code
-			m.message = tt.message
-			m.keyText = tt.keyText
+			t.Parallel()
 
-			c, err := NewClient(&Config{
-				BaseURL: tt.baseURL,
+			s := httptest.NewServer(&MockPKSAdd{
+				t:       t,
+				code:    tt.code,
+				message: tt.message,
+				keyText: tt.keyText,
 			})
+			defer s.Close()
+
+			c, err := NewClient(OptBaseURL(s.URL))
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}
 
-			err = c.PKSAdd(context.Background(), tt.keyText)
+			err = c.PKSAdd(tt.ctx, tt.keyText)
 
-			if tt.code == http.StatusOK {
-				if err != nil {
-					t.Fatalf("failed to do PKS add: %v", err)
-				}
-			} else {
-				if err == nil {
-					t.Fatalf("unexpected success")
-				}
-				if tt.code != 0 {
-					if err, ok := err.(*jsonresp.Error); !ok {
-						t.Fatalf("failed to cast to jsonresp.Error")
-					} else if got, want := err.Code, tt.code; got != want {
-						t.Errorf("got code %v, want %v", got, want)
-					} else if got, want := err.Message, tt.message; got != want {
-						t.Errorf("got message %v, want %v", got, want)
-					}
-				}
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
+				t.Fatalf("got error %v, want %v", got, want)
 			}
 		})
 	}
@@ -224,16 +241,12 @@ func (m *MockPKSLookup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestPKSLookup(t *testing.T) {
-	m := &MockPKSLookup{
-		t:        t,
-		response: "Not valid, but it'll do for testing",
-	}
-	s := httptest.NewServer(m)
-	defer s.Close()
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
 
 	tests := []struct {
 		name          string
-		baseURL       string
+		ctx           context.Context
 		code          int
 		message       string
 		search        string
@@ -244,56 +257,246 @@ func TestPKSLookup(t *testing.T) {
 		pageToken     string
 		pageSize      int
 		nextPageToken string
+		wantErr       error
 	}{
-		{"Get", s.URL, http.StatusOK, "", "search", OperationGet, []string{}, false, false, "", 0, ""},
-		{"GetNPT", s.URL, http.StatusOK, "", "search", OperationGet, []string{}, false, false, "", 0, "bar"},
-		{"GetSize", s.URL, http.StatusOK, "", "search", OperationGet, []string{}, false, false, "", 42, ""},
-		{"GetSizeNPT", s.URL, http.StatusOK, "", "search", OperationGet, []string{}, false, false, "", 42, "bar"},
-		{"GetPT", s.URL, http.StatusOK, "", "search", OperationGet, []string{}, false, false, "foo", 0, ""},
-		{"GetPTNPT", s.URL, http.StatusOK, "", "search", OperationGet, []string{}, false, false, "foo", 0, "bar"},
-		{"GetPTSize", s.URL, http.StatusOK, "", "search", OperationGet, []string{}, false, false, "foo", 42, ""},
-		{"GetPTSizeNPT", s.URL, http.StatusOK, "", "search", OperationGet, []string{}, false, false, "foo", 42, "bar"},
-		{"GetMachineReadable", s.URL, http.StatusOK, "", "search", OperationGet, []string{OptionMachineReadable}, false, false, "", 0, ""},
-		{"GetMachineReadableBlah", s.URL, http.StatusOK, "", "search", OperationGet, []string{OptionMachineReadable, "blah"}, false, false, "", 0, ""},
-		{"GetExact", s.URL, http.StatusOK, "", "search", OperationGet, []string{}, false, true, "", 0, ""},
-		{"Index", s.URL, http.StatusOK, "", "search", OperationIndex, []string{}, false, false, "", 0, ""},
-		{"IndexMachineReadable", s.URL, http.StatusOK, "", "search", OperationIndex, []string{OptionMachineReadable}, false, false, "", 0, ""},
-		{"IndexMachineReadableBlah", s.URL, http.StatusOK, "", "search", OperationIndex, []string{OptionMachineReadable, "blah"}, false, false, "", 0, ""},
-		{"IndexFingerprint", s.URL, http.StatusOK, "", "search", OperationIndex, []string{}, true, false, "", 0, ""},
-		{"IndexExact", s.URL, http.StatusOK, "", "search", OperationIndex, []string{}, false, true, "", 0, ""},
-		{"VIndex", s.URL, http.StatusOK, "", "search", OperationVIndex, []string{}, false, false, "", 0, ""},
-		{"VIndexMachineReadable", s.URL, http.StatusOK, "", "search", OperationVIndex, []string{OptionMachineReadable}, false, false, "", 0, ""},
-		{"VIndexMachineReadableBlah", s.URL, http.StatusOK, "", "search", OperationVIndex, []string{OptionMachineReadable, "blah"}, false, false, "", 0, ""},
-		{"VIndexFingerprint", s.URL, http.StatusOK, "", "search", OperationVIndex, []string{}, true, false, "", 0, ""},
-		{"VIndexExact", s.URL, http.StatusOK, "", "search", OperationVIndex, []string{}, false, true, "", 0, ""},
-		{"BaseURLPath", s.URL + "/path", http.StatusOK, "", "search", OperationGet, []string{}, false, false, "", 0, ""},
-		{"Error", s.URL, http.StatusBadRequest, "", "search", OperationGet, []string{}, false, false, "", 0, ""},
-		{"ErrorMessage", s.URL, http.StatusBadRequest, "blah", "search", OperationGet, []string{}, false, false, "", 0, ""},
-		{"BadURL", "http://127.0.0.1:123456", 0, "", "search", OperationGet, []string{}, false, false, "", 0, ""},
-		{"InvalidSearch", s.URL, 0, "", "", OperationGet, []string{}, false, false, "", 0, ""},
-		{"InvalidOperation", s.URL, 0, "", "search", "", []string{}, false, false, "", 0, ""},
+		{
+			name:   "Get",
+			ctx:    context.Background(),
+			code:   http.StatusOK,
+			search: "search",
+			op:     OperationGet,
+		},
+		{
+			name:          "GetNPT",
+			ctx:           context.Background(),
+			code:          http.StatusOK,
+			search:        "search",
+			op:            OperationGet,
+			nextPageToken: "bar",
+		},
+		{
+			name:     "GetSize",
+			ctx:      context.Background(),
+			code:     http.StatusOK,
+			search:   "search",
+			op:       OperationGet,
+			pageSize: 42,
+		},
+		{
+			name:          "GetSizeNPT",
+			ctx:           context.Background(),
+			code:          http.StatusOK,
+			search:        "search",
+			op:            OperationGet,
+			pageSize:      42,
+			nextPageToken: "bar",
+		},
+		{
+			name:      "GetPT",
+			ctx:       context.Background(),
+			code:      http.StatusOK,
+			search:    "search",
+			op:        OperationGet,
+			pageToken: "foo",
+		},
+		{
+			name:          "GetPTNPT",
+			ctx:           context.Background(),
+			code:          http.StatusOK,
+			search:        "search",
+			op:            OperationGet,
+			pageToken:     "foo",
+			nextPageToken: "bar",
+		},
+		{
+			name:      "GetPTSize",
+			ctx:       context.Background(),
+			code:      http.StatusOK,
+			search:    "search",
+			op:        OperationGet,
+			pageToken: "foo",
+			pageSize:  42,
+		},
+		{
+			name:          "GetPTSizeNPT",
+			ctx:           context.Background(),
+			code:          http.StatusOK,
+			search:        "search",
+			op:            OperationGet,
+			pageToken:     "foo",
+			pageSize:      42,
+			nextPageToken: "bar",
+		},
+		{
+			name:    "GetMachineReadable",
+			ctx:     context.Background(),
+			code:    http.StatusOK,
+			search:  "search",
+			op:      OperationGet,
+			options: []string{OptionMachineReadable},
+		},
+		{
+			name:    "GetMachineReadableBlah",
+			ctx:     context.Background(),
+			code:    http.StatusOK,
+			search:  "search",
+			op:      OperationGet,
+			options: []string{OptionMachineReadable, "blah"},
+		},
+		{
+			name:   "GetExact",
+			ctx:    context.Background(),
+			code:   http.StatusOK,
+			search: "search",
+			op:     OperationGet,
+			exact:  true,
+		},
+		{
+			name:   "Index",
+			ctx:    context.Background(),
+			code:   http.StatusOK,
+			search: "search",
+			op:     OperationIndex,
+		},
+		{
+			name:    "IndexMachineReadable",
+			ctx:     context.Background(),
+			code:    http.StatusOK,
+			search:  "search",
+			op:      OperationIndex,
+			options: []string{OptionMachineReadable},
+		},
+		{
+			name:    "IndexMachineReadableBlah",
+			ctx:     context.Background(),
+			code:    http.StatusOK,
+			search:  "search",
+			op:      OperationIndex,
+			options: []string{OptionMachineReadable, "blah"},
+		},
+		{
+			name:        "IndexFingerprint",
+			ctx:         context.Background(),
+			code:        http.StatusOK,
+			search:      "search",
+			op:          OperationIndex,
+			fingerprint: true,
+		},
+		{
+			name:   "IndexExact",
+			ctx:    context.Background(),
+			code:   http.StatusOK,
+			search: "search",
+			op:     OperationIndex,
+			exact:  true,
+		},
+		{
+			name:   "VIndex",
+			ctx:    context.Background(),
+			code:   http.StatusOK,
+			search: "search",
+			op:     OperationVIndex,
+		},
+		{
+			name:    "VIndexMachineReadable",
+			ctx:     context.Background(),
+			code:    http.StatusOK,
+			search:  "search",
+			op:      OperationVIndex,
+			options: []string{OptionMachineReadable},
+		},
+		{
+			name:    "VIndexMachineReadableBlah",
+			ctx:     context.Background(),
+			code:    http.StatusOK,
+			search:  "search",
+			op:      OperationVIndex,
+			options: []string{OptionMachineReadable, "blah"},
+		},
+		{
+			name:        "VIndexFingerprint",
+			ctx:         context.Background(),
+			code:        http.StatusOK,
+			search:      "search",
+			op:          OperationVIndex,
+			fingerprint: true,
+		},
+		{
+			name:   "VIndexExact",
+			ctx:    context.Background(),
+			code:   http.StatusOK,
+			search: "search",
+			op:     OperationVIndex,
+			exact:  true,
+		},
+		{
+			name:    "HTTPError",
+			ctx:     context.Background(),
+			code:    http.StatusBadRequest,
+			search:  "search",
+			op:      OperationGet,
+			wantErr: &HTTPError{code: http.StatusBadRequest},
+		},
+		{
+			name:    "HTTPErrorMessage",
+			ctx:     context.Background(),
+			code:    http.StatusBadRequest,
+			message: "blah",
+			search:  "search",
+			op:      OperationGet,
+			wantErr: &HTTPError{code: http.StatusBadRequest},
+		},
+		{
+			name:    "ContextCanceled",
+			ctx:     cancelled,
+			code:    http.StatusOK,
+			search:  "search",
+			op:      OperationGet,
+			wantErr: context.Canceled,
+		},
+		{
+			name:    "InvalidSearch",
+			ctx:     context.Background(),
+			code:    http.StatusOK,
+			op:      OperationGet,
+			wantErr: ErrInvalidSearch,
+		},
+		{
+			name:    "InvalidOperation",
+			ctx:     context.Background(),
+			code:    http.StatusOK,
+			search:  "search",
+			options: []string{},
+			wantErr: ErrInvalidOperation,
+		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			m.code = tt.code
-			m.message = tt.message
-			m.search = tt.search
-			m.op = tt.op
-			m.options = strings.Join(tt.options, ",")
-			m.fingerprint = tt.fingerprint
-			m.exact = tt.exact
-			m.pageToken = tt.pageToken
-			if tt.pageSize == 0 {
-				m.pageSize = ""
-			} else {
+			t.Parallel()
+
+			m := MockPKSLookup{
+				t:             t,
+				response:      "Not valid, but it'll do for testing",
+				code:          tt.code,
+				message:       tt.message,
+				search:        tt.search,
+				op:            tt.op,
+				options:       strings.Join(tt.options, ","),
+				fingerprint:   tt.fingerprint,
+				exact:         tt.exact,
+				pageToken:     tt.pageToken,
+				nextPageToken: tt.nextPageToken,
+			}
+			if tt.pageSize != 0 {
 				m.pageSize = strconv.Itoa(tt.pageSize)
 			}
-			m.nextPageToken = tt.nextPageToken
 
-			c, err := NewClient(&Config{
-				BaseURL: tt.baseURL,
-			})
+			s := httptest.NewServer(&m)
+			defer s.Close()
+
+			c, err := NewClient(OptBaseURL(s.URL))
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}
@@ -302,30 +505,18 @@ func TestPKSLookup(t *testing.T) {
 				Token: tt.pageToken,
 				Size:  tt.pageSize,
 			}
-			r, err := c.PKSLookup(context.Background(), &pd, tt.search, tt.op, tt.fingerprint, tt.exact, tt.options)
+			r, err := c.PKSLookup(tt.ctx, &pd, tt.search, tt.op, tt.fingerprint, tt.exact, tt.options)
 
-			if tt.code == http.StatusOK {
-				if err != nil {
-					t.Fatalf("failed to do PKS lookup: %v", err)
-				}
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
+				t.Fatalf("got error %v, want %v", got, want)
+			}
+
+			if err == nil {
 				if got, want := pd.Token, tt.nextPageToken; got != want {
 					t.Errorf("got page token %v, want %v", got, want)
 				}
 				if got, want := r, m.response; got != want {
 					t.Errorf("got response %v, want %v", got, want)
-				}
-			} else {
-				if err == nil {
-					t.Fatalf("unexpected success")
-				}
-				if 0 != tt.code {
-					if err, ok := err.(*jsonresp.Error); !ok {
-						t.Fatalf("failed to cast to jsonresp.Error")
-					} else if got, want := err.Code, tt.code; got != want {
-						t.Errorf("got code %v, want %v", got, want)
-					} else if got, want := err.Message, tt.message; got != want {
-						t.Errorf("got message %v, want %v", got, want)
-					}
 				}
 			}
 		})
@@ -339,67 +530,103 @@ func TestGetKey(t *testing.T) {
 		0x10, 0x11, 0x12, 0x13,
 	}
 
-	m := &MockPKSLookup{
-		t:        t,
-		op:       OperationGet,
-		exact:    true,
-		response: "Not valid, but it'll do for testing",
-	}
-	s := httptest.NewServer(m)
-	defer s.Close()
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
 
 	tests := []struct {
 		name    string
-		baseURL string
+		ctx     context.Context
 		code    int
 		message string
 		search  []byte
+		wantErr error
 	}{
-		{"ShortKeyID", s.URL, http.StatusOK, "", search[len(search)-4:]},
-		{"KeyID", s.URL, http.StatusOK, "", search[len(search)-8:]},
-		{"V3Fingerprint", s.URL, http.StatusOK, "", search[len(search)-16:]},
-		{"V4Fingerprint", s.URL, http.StatusOK, "", search},
-		{"BaseURLPath", s.URL + "/path", http.StatusOK, "", search},
-		{"Error", s.URL, http.StatusBadRequest, "", search},
-		{"ErrorMessage", s.URL, http.StatusBadRequest, "blah", search},
-		{"BadURL", "http://127.0.0.1:123456", 0, "", search},
-		{"InvalidSearch", s.URL, 0, "", search[:1]},
+		{
+			name:   "ShortKeyID",
+			ctx:    context.Background(),
+			code:   http.StatusOK,
+			search: search[len(search)-4:],
+		},
+		{
+			name:   "KeyID",
+			ctx:    context.Background(),
+			code:   http.StatusOK,
+			search: search[len(search)-8:],
+		},
+		{
+			name:   "V3Fingerprint",
+			ctx:    context.Background(),
+			code:   http.StatusOK,
+			search: search[len(search)-16:],
+		},
+		{
+			name:   "V4Fingerprint",
+			ctx:    context.Background(),
+			code:   http.StatusOK,
+			search: search,
+		},
+		{
+			name:    "HTTPError",
+			ctx:     context.Background(),
+			code:    http.StatusBadRequest,
+			search:  search,
+			wantErr: &HTTPError{code: http.StatusBadRequest},
+		},
+		{
+			name:    "HTTPErrorMessage",
+			ctx:     context.Background(),
+			code:    http.StatusBadRequest,
+			message: "blah",
+			search:  search,
+			wantErr: &HTTPError{code: http.StatusBadRequest},
+		},
+		{
+			name:    "ContextCanceled",
+			ctx:     cancelled,
+			code:    http.StatusOK,
+			search:  search,
+			wantErr: context.Canceled,
+		},
+		{
+			name:    "InvalidSearch",
+			ctx:     context.Background(),
+			search:  search[:1],
+			wantErr: ErrInvalidSearch,
+		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			m.code = tt.code
-			m.message = tt.message
-			m.search = fmt.Sprintf("%#x", tt.search)
+			t.Parallel()
 
-			c, err := NewClient(&Config{
-				BaseURL: tt.baseURL,
-			})
+			m := MockPKSLookup{
+				t:        t,
+				code:     tt.code,
+				message:  tt.message,
+				search:   fmt.Sprintf("%#x", tt.search),
+				op:       OperationGet,
+				exact:    true,
+				response: "Not valid, but it'll do for testing",
+			}
+
+			s := httptest.NewServer(&m)
+			defer s.Close()
+
+			c, err := NewClient(OptBaseURL(s.URL))
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}
 
-			kt, err := c.GetKey(context.Background(), tt.search)
+			kt, err := c.GetKey(tt.ctx, tt.search)
 
-			if tt.code == http.StatusOK {
-				if err != nil {
-					t.Fatalf("failed to get key: %v", err)
-				}
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
+				t.Fatalf("got error %v, want %v", got, want)
+			}
+
+			if err == nil {
 				if got, want := kt, m.response; got != want {
 					t.Errorf("got keyText %v, want %v", got, want)
-				}
-			} else {
-				if err == nil {
-					t.Fatalf("unexpected success")
-				}
-				if tt.code != 0 {
-					if err, ok := err.(*jsonresp.Error); !ok {
-						t.Fatalf("failed to cast to jsonresp.Error")
-					} else if got, want := err.Code, tt.code; got != want {
-						t.Errorf("got code %v, want %v", got, want)
-					} else if got, want := err.Message, tt.message; got != want {
-						t.Errorf("got message %v, want %v", got, want)
-					}
 				}
 			}
 		})

--- a/client/version.go
+++ b/client/version.go
@@ -39,7 +39,7 @@ func (c *Client) GetVersion(ctx context.Context) (vi VersionInfo, err error) {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode/100 != 2 { // non-2xx status code
 		return VersionInfo{}, fmt.Errorf("%w", errorFromResponse(res))
 	}
 

--- a/client/version.go
+++ b/client/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -7,7 +7,9 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/url"
 
 	jsonresp "github.com/sylabs/json-resp"
 )
@@ -21,20 +23,28 @@ type VersionInfo struct {
 
 // GetVersion gets version information from the Key Service. The context controls the lifetime of
 // the request.
+//
+// If an non-200 HTTP status code is received, an error wrapping an HTTPError is returned.
 func (c *Client) GetVersion(ctx context.Context) (vi VersionInfo, err error) {
-	req, err := c.NewRequest(http.MethodGet, pathVersion, "", nil)
+	ref := &url.URL{Path: pathVersion}
+
+	req, err := c.NewRequest(ctx, http.MethodGet, ref, nil)
 	if err != nil {
-		return VersionInfo{}, err
+		return VersionInfo{}, fmt.Errorf("%w", err)
 	}
 
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.Do(req)
 	if err != nil {
-		return VersionInfo{}, err
+		return VersionInfo{}, fmt.Errorf("%w", err)
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode != http.StatusOK {
+		return VersionInfo{}, fmt.Errorf("%w", errorFromResponse(res))
+	}
+
 	if err := jsonresp.ReadResponse(res.Body, &vi); err != nil {
-		return VersionInfo{}, err
+		return VersionInfo{}, fmt.Errorf("%w", err)
 	}
 	return vi, nil
 }

--- a/client/version.go
+++ b/client/version.go
@@ -16,35 +16,33 @@ import (
 
 const pathVersion = "version"
 
-// VersionInfo contains version information.
-type VersionInfo struct {
-	Version string `json:"version"`
-}
-
 // GetVersion gets version information from the Key Service. The context controls the lifetime of
 // the request.
 //
 // If an non-200 HTTP status code is received, an error wrapping an HTTPError is returned.
-func (c *Client) GetVersion(ctx context.Context) (vi VersionInfo, err error) {
+func (c *Client) GetVersion(ctx context.Context) (string, error) {
 	ref := &url.URL{Path: pathVersion}
 
 	req, err := c.NewRequest(ctx, http.MethodGet, ref, nil)
 	if err != nil {
-		return VersionInfo{}, fmt.Errorf("%w", err)
+		return "", fmt.Errorf("%w", err)
 	}
 
 	res, err := c.Do(req)
 	if err != nil {
-		return VersionInfo{}, fmt.Errorf("%w", err)
+		return "", fmt.Errorf("%w", err)
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 { // non-2xx status code
-		return VersionInfo{}, fmt.Errorf("%w", errorFromResponse(res))
+		return "", fmt.Errorf("%w", errorFromResponse(res))
 	}
 
+	vi := struct {
+		Version string `json:"version"`
+	}{}
 	if err := jsonresp.ReadResponse(res.Body, &vi); err != nil {
-		return VersionInfo{}, fmt.Errorf("%w", err)
+		return "", fmt.Errorf("%w", err)
 	}
-	return vi, nil
+	return vi.Version, nil
 }

--- a/client/version_test.go
+++ b/client/version_test.go
@@ -24,7 +24,7 @@ type MockVersion struct {
 }
 
 func (m *MockVersion) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if m.code != http.StatusOK {
+	if m.code/100 != 2 { // non-2xx status code
 		if err := jsonresp.WriteError(w, m.message, m.code); err != nil {
 			m.t.Fatalf("failed to write error: %v", err)
 		}
@@ -74,6 +74,13 @@ func TestGetVersion(t *testing.T) {
 			ctx:      context.Background(),
 			code:     http.StatusOK,
 			wantPath: "/path/version",
+			version:  "1.2.3",
+		},
+		{
+			name:     "NonAuthoritativeInfo",
+			ctx:      context.Background(),
+			code:     http.StatusNonAuthoritativeInfo,
+			wantPath: "/version",
 			version:  "1.2.3",
 		},
 		{

--- a/client/version_test.go
+++ b/client/version_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,13 +18,14 @@ import (
 type MockVersion struct {
 	t        *testing.T
 	code     int
+	message  string
 	wantPath string
 	version  string
 }
 
 func (m *MockVersion) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if m.code != http.StatusOK {
-		if err := jsonresp.WriteError(w, "", m.code); err != nil {
+		if err := jsonresp.WriteError(w, m.message, m.code); err != nil {
 			m.t.Fatalf("failed to write error: %v", err)
 		}
 		return
@@ -46,57 +48,83 @@ func (m *MockVersion) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetVersion(t *testing.T) {
-	m := &MockVersion{
-		t: t,
-	}
-	s := httptest.NewServer(m)
-	defer s.Close()
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
 
 	tests := []struct {
 		name     string
-		baseURL  string
+		path     string
+		ctx      context.Context
 		code     int
+		message  string
 		wantPath string
 		version  string
+		wantErr  error
 	}{
-		{"Success", s.URL, http.StatusOK, "/version", "1.2.3"},
-		{"SuccessPath", s.URL + "/path", http.StatusOK, "/path/version", "1.2.3"},
-		{"JSONError", s.URL, http.StatusBadRequest, "", ""},
-		{"BadURL", "http://127.0.0.1:123456", 0, "", ""},
+		{
+			name:     "OK",
+			ctx:      context.Background(),
+			code:     http.StatusOK,
+			wantPath: "/version",
+			version:  "1.2.3",
+		},
+		{
+			name:     "OKWithPath",
+			path:     "/path",
+			ctx:      context.Background(),
+			code:     http.StatusOK,
+			wantPath: "/path/version",
+			version:  "1.2.3",
+		},
+		{
+			name:    "HTTPError",
+			ctx:     context.Background(),
+			code:    http.StatusBadRequest,
+			wantErr: &HTTPError{code: http.StatusBadRequest},
+		},
+		{
+			name:    "HTTPErrorMessage",
+			ctx:     context.Background(),
+			code:    http.StatusBadRequest,
+			message: "blah",
+			wantErr: &HTTPError{code: http.StatusBadRequest},
+		},
+		{
+			name:    "ContextCanceled",
+			ctx:     cancelled,
+			code:    http.StatusOK,
+			wantErr: context.Canceled,
+		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			m.code = tt.code
-			m.wantPath = tt.wantPath
-			m.version = tt.version
+			t.Parallel()
 
-			c, err := NewClient(&Config{
-				BaseURL: tt.baseURL,
+			s := httptest.NewServer(&MockVersion{
+				t:        t,
+				code:     tt.code,
+				message:  tt.message,
+				wantPath: tt.wantPath,
+				version:  tt.version,
 			})
+			defer s.Close()
+
+			c, err := NewClient(OptBaseURL(s.URL + tt.path))
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}
 
-			vi, err := c.GetVersion(context.Background())
+			vi, err := c.GetVersion(tt.ctx)
 
-			if tt.code == http.StatusOK {
-				if err != nil {
-					t.Fatalf("failed to get version: %v", err)
-				}
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
+				t.Fatalf("got error %v, want %v", got, want)
+			}
+
+			if err == nil {
 				if got, want := vi.Version, tt.version; got != want {
 					t.Errorf("got version %v, want %v", got, want)
-				}
-			} else {
-				if err == nil {
-					t.Fatalf("unexpected success")
-				}
-				if tt.code != 0 {
-					if err, ok := err.(*jsonresp.Error); !ok {
-						t.Fatalf("failed to cast to jsonresp.Error")
-					} else if got, want := err.Code, tt.code; got != want {
-						t.Errorf("got code %v, want %v", got, want)
-					}
 				}
 			}
 		})

--- a/client/version_test.go
+++ b/client/version_test.go
@@ -39,7 +39,9 @@ func (m *MockVersion) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		m.t.Errorf("got content length %v, want %v", got, want)
 	}
 
-	vi := VersionInfo{
+	vi := struct {
+		Version string `json:"version"`
+	}{
 		Version: m.version,
 	}
 	if err := jsonresp.WriteResponse(w, vi, m.code); err != nil {
@@ -123,14 +125,14 @@ func TestGetVersion(t *testing.T) {
 				t.Fatalf("failed to create client: %v", err)
 			}
 
-			vi, err := c.GetVersion(tt.ctx)
+			v, err := c.GetVersion(tt.ctx)
 
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
 			}
 
 			if err == nil {
-				if got, want := vi.Version, tt.version; got != want {
+				if got, want := v, tt.version; got != want {
 					t.Errorf("got version %v, want %v", got, want)
 				}
 			}


### PR DESCRIPTION
Use functional arguments for `NewClient`. Modify `(*Client).NewRequest` to accept a context and a relative URL reference. Add `(*Client).Do` method. Add `HTTPError` type to represent unsuccessful HTTP responses, utilizing Go 1.13 error wrapping. Improve documentation around errors. Improve testing.

Return version string directly from `(*Client).GetVersion`.

Accept all 2xx HTTP status codes as successful.