### PR TITLE
CI Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:14-slim
+      - image: node:15-slim
   golang:
     docker:
       - image: golang:1.15

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: golang:1.15
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.30-alpine
+      - image: golangci/golangci-lint:v1.32-alpine
 
 jobs:
   lint_markdown:


### PR DESCRIPTION
Bump `node` to v15, and `golangci-lint` to v1.32.