### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: golang:1.16
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.32-alpine
+      - image: golangci/golangci-lint:v1.39-alpine
 
 jobs:
   lint_markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:15-slim
   golang:
     docker:
-      - image: golang:1.15
+      - image: golang:1.16
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.32-alpine

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,8 +20,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
-    - maligned
     - misspell
     - nakedret
     - prealloc

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sylabs/scs-key-client
 
-go 1.14
+go 1.15
 
 require github.com/sylabs/json-resp v0.7.1


### PR DESCRIPTION
Bump `golang` to 1.16, and `golangci-lint` to 1.39. Remove deprecated `interfacer` and `maligned` linters.