### PR TITLE
CI Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:15-slim
+      - image: node:16-slim
   golang:
     docker:
       - image: golang:1.16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: golang:1.16
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.39-alpine
+      - image: golangci/golangci-lint:v1.40-alpine
 
 jobs:
   lint_markdown:


### PR DESCRIPTION
Update `node` to 16.x, and `golangci-lint` to 1.40.x.