### PR TITLE
Bump Go to 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.41-alpine
   golang-previous:
     docker:
-      - image: golang:1.15
+      - image: golang:1.16
   golang-latest:
     docker:
-      - image: golang:1.16
+      - image: golang:1.17
 
 jobs:
   lint-markdown:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -8,7 +8,7 @@ package client
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -226,7 +226,7 @@ func TestNewRequest(t *testing.T) {
 					t.Errorf("got URL %v, want %v", got, want)
 				}
 
-				b, err := ioutil.ReadAll(r.Body)
+				b, err := io.ReadAll(r.Body)
 				if err != nil {
 					t.Errorf("failed to read body: %v", err)
 				}

--- a/client/pks.go
+++ b/client/pks.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -137,7 +137,7 @@ func (c *Client) PKSLookup(ctx context.Context, pd *PageDetails, search, operati
 		pd.Token = res.Header.Get("X-HKP-Next-Page-Token")
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", fmt.Errorf("%w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sylabs/scs-key-client
 
-go 1.15
+go 1.17
 
 require github.com/sylabs/json-resp v0.7.1


### PR DESCRIPTION
Bump `go.mod` language version to 1.17 to take advantage of [lazy loading](https://golang.org/ref/mod#lazy-loading). Bump CI Go version range to 1.16-1.17. Remove use of deprecated `ioutil` package.