### PR TITLE
Bump Codecov Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.2
+  codecov: codecov/codecov@3
 
 executors:
   node:


### PR DESCRIPTION
Bump [Codecov Orb](https://circleci.com/developer/orbs/orb/codecov/codecov) to latest major version.