### PR TITLE
CI Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:16-slim
+      - image: node:17-slim
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.43-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:17-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.43-alpine
+      - image: golangci/golangci-lint:v1.44-alpine
   golang-previous:
     docker:
       - image: golang:1.16

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,12 +3,15 @@ linters:
   enable:
     - bidichk
     - bodyclose
+    - containedctx
     - contextcheck
     - deadcode
+    - decorder
     - depguard
     - dogsled
     - dupl
     - errcheck
+    - errchkjson
     - gochecknoinits
     - goconst
     - gocritic
@@ -20,8 +23,10 @@ linters:
     - gosec
     - gosimple
     - govet
+    - grouper
     - ineffassign
     - ireturn
+    - maintidx
     - misspell
     - nakedret
     - nilnil

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,7 @@
 # LICENSE
 
+Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

--- a/client/pks_test.go
+++ b/client/pks_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -60,7 +60,7 @@ func TestPKSAdd(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		ctx     context.Context
+		ctx     context.Context //nolint:containedctx
 		keyText string
 		code    int
 		message string
@@ -246,13 +246,14 @@ func (m *MockPKSLookup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+//nolint:maintidx
 func TestPKSLookup(t *testing.T) {
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	tests := []struct {
 		name          string
-		ctx           context.Context
+		ctx           context.Context //nolint:containedctx
 		code          int
 		message       string
 		search        string
@@ -548,7 +549,7 @@ func TestGetKey(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		ctx     context.Context
+		ctx     context.Context //nolint:containedctx
 		code    int
 		message string
 		search  []byte

--- a/client/version_test.go
+++ b/client/version_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -56,7 +56,7 @@ func TestGetVersion(t *testing.T) {
 	tests := []struct {
 		name     string
 		path     string
-		ctx      context.Context
+		ctx      context.Context //nolint:containedctx
 		code     int
 		message  string
 		wantPath string


### PR DESCRIPTION
Bump `node` to v17, and `golangci-lint` to v1.44.