### PR TITLE
Bump golangci-lint to v1.45

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:17-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.44-alpine
+      - image: golangci/golangci-lint:v1.45-alpine
   golang-previous:
     docker:
       - image: golang:1.17


### PR DESCRIPTION
Bump `golangci-lint` to v1.45, which formally adds support for Go 1.18.